### PR TITLE
Remove frontend dependencies on oxart.tools.common_args

### DIFF
--- a/oxart/devices/brooks_4850/logger.py
+++ b/oxart/devices/brooks_4850/logger.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import time
 import influxdb
 
-from sipyco.common_args import add_common_args, init_logger_from_args
+import sipyco.common_args as sca
 from sipyco.pc_rpc import Client
 
 logger = logging.getLogger(__name__)
@@ -28,13 +28,13 @@ def get_argparser():
                         help="address of flow controller",
                         default="10.255.6.178")
     parser.add_argument("-p", "--port", help="port for flow controller", default="9001")
-    add_common_args(parser)  # This adds the -q and -v handling
+    sca.verbosity_args(parser)  # This adds the -q and -v handling
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     while True:
         try:

--- a/oxart/frontend/aqctl_andor_emccd.py
+++ b/oxart/frontend/aqctl_andor_emccd.py
@@ -5,8 +5,7 @@ import logging
 import types
 
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 import andorEmccd
 
 logger = logging.getLogger(__name__)
@@ -14,8 +13,8 @@ logger = logging.getLogger(__name__)
 
 def get_argparser():
     parser = argparse.ArgumentParser()
-    simple_network_args(parser, 4000)
-    add_common_args(parser)
+    sca.simple_network_args(parser, 4000)
+    sca.verbosity_args(parser)
     parser.add_argument("--temp", default=-80, type=int)
     parser.add_argument("--broadcast-images", action="store_true")
     parser.add_argument("--zmq-bind", default="*")
@@ -33,7 +32,7 @@ def create_zmq_server(bind="*", port=5555):
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     def ping(self):
         # This raise an exception if the camera has been turned off, unplugged,

--- a/oxart/frontend/aqctl_booster.py
+++ b/oxart/frontend/aqctl_booster.py
@@ -5,8 +5,7 @@ import logging
 
 from oxart.devices.booster.driver import Booster
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 logger = logging.getLogger(__name__)
 
@@ -15,14 +14,14 @@ def get_argparser():
     parser = argparse.ArgumentParser(description="ARTIQ controller for Booster"
                                      " 8-channel RF power amplifier")
     parser.add_argument("-d", "--device", help="device's IP address")
-    simple_network_args(parser, 4300)
-    add_common_args(parser)
+    sca.simple_network_args(parser, 4300)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = Booster(args.device)
 

--- a/oxart/frontend/aqctl_current_stabilizer.py
+++ b/oxart/frontend/aqctl_current_stabilizer.py
@@ -5,9 +5,8 @@ import asyncio
 import logging
 
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
+import sipyco.common_args as sca
 from oxart.devices.stabilizer.current_stabilizer import Stabilizer
-from oxart.tools import add_common_args
 
 logger = logging.getLogger(__name__)
 
@@ -17,8 +16,8 @@ def get_argparser():
         description="ARTIQ controller for stabilizer_current_sense controller")
     parser.add_argument("-d", "--device", help="Device IP address")
 
-    simple_network_args(parser, 4300)
-    add_common_args(parser)
+    sca.simple_network_args(parser, 4300)
+    sca.verbosity_args(parser)
     return parser
 
 
@@ -30,7 +29,7 @@ async def open_connections(device_host):
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     loop = asyncio.get_event_loop()
     fb, ff = loop.run_until_complete(open_connections(args.device))

--- a/oxart/frontend/aqctl_scpi_dmm.py
+++ b/oxart/frontend/aqctl_scpi_dmm.py
@@ -5,8 +5,7 @@ import logging
 
 from oxart.devices.scpi_dmm.driver import ScpiDmm
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 logger = logging.getLogger(__name__)
 
@@ -16,15 +15,15 @@ def get_argparser():
                                      "SCPI Digital Multi Meters")
     parser.add_argument("-d", "--device", help="device's hardware address")
 
-    simple_network_args(parser, 4300)
-    add_common_args(parser)
+    sca.simple_network_args(parser, 4300)
+    sca.verbosity_args(parser)
 
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = ScpiDmm(args.device)
 

--- a/oxart/frontend/aqctl_scpi_synth.py
+++ b/oxart/frontend/aqctl_scpi_synth.py
@@ -5,8 +5,7 @@ import logging
 
 from oxart.devices.scpi_synth.driver import Synth
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 logger = logging.getLogger(__name__)
 
@@ -14,14 +13,14 @@ logger = logging.getLogger(__name__)
 def get_argparser():
     parser = argparse.ArgumentParser(description="ARTIQ controller for SCPI Synths")
     parser.add_argument("-d", "--device", help="device's hardware address")
-    simple_network_args(parser, 4300)
-    add_common_args(parser)
+    sca.simple_network_args(parser, 4300)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = Synth(args.device)
 

--- a/oxart/frontend/aqctl_surf_solver.py
+++ b/oxart/frontend/aqctl_surf_solver.py
@@ -4,14 +4,13 @@ import argparse
 
 from oxart.devices.surf_solver.driver import SURF
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
     parser = argparse.ArgumentParser(description="ARTIQ controller for SURF")
-    simple_network_args(parser, 4000)
-    add_common_args(parser)
+    sca.simple_network_args(parser, 4000)
+    sca.verbosity_args(parser)
     parser.add_argument("--trap_model_path",
                         default="/home/ion/scratch/julia_projects/"
                         "SURF/trap_model/comet_model.jld",
@@ -26,7 +25,7 @@ def get_argparser():
 def main():
     print("starting controller")
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = SURF(args.trap_model_path, args.cache_path)
 

--- a/oxart/frontend/aqctl_v3500a.py
+++ b/oxart/frontend/aqctl_v3500a.py
@@ -5,8 +5,7 @@ import logging
 
 from oxart.devices.v3500a.driver import V3500A
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 logger = logging.getLogger(__name__)
 
@@ -15,14 +14,14 @@ def get_argparser():
     parser = argparse.ArgumentParser(description="ARTIQ controller for "
                                      "Keysight V3500A RF power meter")
     parser.add_argument("-d", "--device", help="device's address")
-    simple_network_args(parser, 4300)
-    add_common_args(parser)
+    sca.simple_network_args(parser, 4300)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = V3500A(args.device)
 

--- a/oxart/frontend/arduino_dac_controller.py
+++ b/oxart/frontend/arduino_dac_controller.py
@@ -5,8 +5,7 @@ import sys
 
 from oxart.devices.arduino_dac.driver import ArduinoDAC
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
@@ -17,14 +16,14 @@ def get_argparser():
                         help="serial device. See documentation for how to "
                         "specify a USB Serial Number.")
 
-    simple_network_args(parser, 2030)
-    add_common_args(parser)
+    sca.simple_network_args(parser, 2030)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     if args.device is None:
         print("You need to specify -d/--device "

--- a/oxart/frontend/arduino_dds_controller.py
+++ b/oxart/frontend/arduino_dds_controller.py
@@ -5,8 +5,7 @@ import sys
 
 from artiq_drivers.devices.arduino_dds.driver import ArduinoDDS, ArduinoDDSSim
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
@@ -25,14 +24,14 @@ def get_argparser():
                         type=float,
                         help="clock frequency provided to DDS")
 
-    simple_network_args(parser, 2000)
-    add_common_args(parser)
+    sca.simple_network_args(parser, 2000)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     if not args.simulation and args.device is None:
         print("You need to specify either --simulation or -d/--device "

--- a/oxart/frontend/bb_shutter_controller.py
+++ b/oxart/frontend/bb_shutter_controller.py
@@ -4,21 +4,20 @@ import argparse
 
 from oxart.devices.bb_shutter.driver import BBShutter
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
     parser = argparse.ArgumentParser(
         description="ARTIQ controller for the BeagleBone 4-channel shutter driver")
-    simple_network_args(parser, 4000)
-    add_common_args(parser)
+    sca.simple_network_args(parser, 4000)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = BBShutter()
 

--- a/oxart/frontend/bme_pulse_picker_timing_controller.py
+++ b/oxart/frontend/bme_pulse_picker_timing_controller.py
@@ -5,27 +5,26 @@ import argparse
 from oxart.devices.bme_pulse_picker.bme_delay_gen import ClockSource, Driver
 from oxart.devices.bme_pulse_picker.timing import PulsePickerTiming
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import (init_logger_from_args, simple_network_args,
-                                verbosity_args)
+import sipyco.common_args as sca
 
 
 def get_argparser():
     parser = argparse.ArgumentParser(
         description="ARTIQ controller for BME delay generator PCI card")
-    simple_network_args(parser, 4007)
+    sca.simple_network_args(parser, 4007)
     parser.add_argument("-s",
                         "--simulation",
                         default=False,
                         action="store_true",
                         help="Put the driver in simulation mode")
     parser.add_argument("--allow-long-pulses", default=False, action="store_true")
-    verbosity_args(parser)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     delay_gen = None
     if not args.simulation:

--- a/oxart/frontend/conex_motor_controller.py
+++ b/oxart/frontend/conex_motor_controller.py
@@ -5,15 +5,13 @@ import sys
 
 from oxart.devices.conex_motor.driver import Conex
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import (simple_network_args, init_logger_from_args,
-                                bind_address_from_args)
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
     parser = argparse.ArgumentParser(description="ARTIQ controller for "
                                      "Newport CONEX motorised micrometer")
-    simple_network_args(parser, 4000)
+    sca.simple_network_args(parser, 4000)
     parser.add_argument("-d",
                         "--device",
                         default=None,
@@ -29,13 +27,13 @@ def get_argparser():
                         type=float,
                         help="Maximum extension of micrometer (limit loaded \
                         into hardware")
-    add_common_args(parser)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     if args.device is None:
         print("You need to specify a -d/--device "
@@ -50,7 +48,7 @@ def main():
     # A: We don't want to try to close the serial if sys.exit() is called,
     #    and sys.exit() isn't caught by Exception
     try:
-        simple_server_loop({"conex": dev}, bind_address_from_args(args), args.port)
+        simple_server_loop({"conex": dev}, sca.bind_address_from_args(args), args.port)
     except Exception:
         dev.close()
     else:

--- a/oxart/frontend/hoa2_dac_controller.py
+++ b/oxart/frontend/hoa2_dac_controller.py
@@ -5,8 +5,7 @@ import sys
 
 from oxart.devices.hoa2_dac.driver import HOA2Dac
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
@@ -17,14 +16,14 @@ def get_argparser():
                         help="serial device. See documentation for how to "
                         "specify a USB Serial Number.")
 
-    simple_network_args(parser, 2030)
-    add_common_args(parser)
+    sca.simple_network_args(parser, 2030)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     if args.device is None:
         print("You need to specify -d/--device "

--- a/oxart/frontend/holzworth_synth_controller.py
+++ b/oxart/frontend/holzworth_synth_controller.py
@@ -4,22 +4,21 @@ import argparse
 
 from oxart.devices.holzworth_synth.driver import HolzworthSynth
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
     parser = argparse.ArgumentParser(
         description="ARTIQ controller for the Holzworth synth "
         "on the Quadrupole laser system")
-    simple_network_args(parser, 4000)
-    add_common_args(parser)
+    sca.simple_network_args(parser, 4000)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = HolzworthSynth()  # Starts frequency update loop to track cavity drift
 

--- a/oxart/frontend/ophir_controller.py
+++ b/oxart/frontend/ophir_controller.py
@@ -4,31 +4,29 @@ import argparse
 
 from oxart.devices.ophir.driver import OphirPowerMeter
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import (simple_network_args, init_logger_from_args,
-                                bind_address_from_args)
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
     parser = argparse.ArgumentParser(description="ARTIQ controller for the "
                                      "Ophir power meter")
-    simple_network_args(parser, 4000)
+    sca.simple_network_args(parser, 4000)
     parser.add_argument("-d",
                         "--device",
                         default=None,
                         help="Device serial number. This is the unit no., "
                         "not that of the sensor")
-    add_common_args(parser)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = OphirPowerMeter(args.device)
 
-    simple_server_loop({"ophir": dev}, bind_address_from_args(args), args.port)
+    simple_server_loop({"ophir": dev}, sca.bind_address_from_args(args), args.port)
 
 
 if __name__ == "__main__":

--- a/oxart/frontend/picomotor_controller.py
+++ b/oxart/frontend/picomotor_controller.py
@@ -4,26 +4,24 @@ import argparse
 
 from oxart.devices.picomotor.driver import PicomotorController
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import (simple_network_args, init_logger_from_args,
-                                bind_address_from_args)
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def main():
     parser = argparse.ArgumentParser(description="ARTIQ Picomotor controller")
-    simple_network_args(parser, 4006)
+    sca.simple_network_args(parser, 4006)
     parser.add_argument("-d",
                         "--device",
                         help="IP address of controller",
                         required=True)
-    add_common_args(parser)
+    sca.verbosity_args(parser)
     args = parser.parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = PicomotorController(args.device)
     try:
-        simple_server_loop({'picomotorController': dev}, bind_address_from_args(args),
-                           args.port)
+        simple_server_loop({'picomotorController': dev},
+                           sca.bind_address_from_args(args), args.port)
     finally:
         dev.close()
 

--- a/oxart/frontend/scpi_awg_controller.py
+++ b/oxart/frontend/scpi_awg_controller.py
@@ -5,8 +5,7 @@ import sys
 
 from oxart.devices.scpi_device.awg import SCPIAWG
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
@@ -16,14 +15,14 @@ def get_argparser():
                         "--serialnumber",
                         default=None,
                         help="Serial number of device to check identity")
-    simple_network_args(parser, 4004)
-    add_common_args(parser)
+    sca.simple_network_args(parser, 4004)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     if args.ipaddr is None:
         print("You need to specify -i/--ipaddr. Use --help for more information.")

--- a/oxart/frontend/thorlabs_bpc303_controller.py
+++ b/oxart/frontend/thorlabs_bpc303_controller.py
@@ -4,15 +4,14 @@ import argparse
 
 from oxart.devices.thorlabs_bpc303.driver import BPC303
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
     parser = argparse.ArgumentParser(
         description="ARTIQ controller for the "
         "Thorlabs BPC303 3 channel closed-loop piezo controller")
-    simple_network_args(parser, 5004)
+    sca.simple_network_args(parser, 5004)
     parser.add_argument("-d",
                         "--device",
                         default=None,
@@ -23,13 +22,13 @@ def get_argparser():
                         "--closedloop",
                         action="store_true",
                         help="Use in closed-loop mode?")
-    add_common_args(parser)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = BPC303(args.device, args.closedloop)
 

--- a/oxart/frontend/thorlabs_ddr05_controller.py
+++ b/oxart/frontend/thorlabs_ddr05_controller.py
@@ -4,15 +4,13 @@ import argparse
 
 from oxart.devices.thorlabs_apt.driver import DDR05
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import (simple_network_args, init_logger_from_args,
-                                bind_address_from_args)
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
     parser = argparse.ArgumentParser(description="ARTIQ controller for the "
                                      "Thorlabs DDR05 motorised rotation mount")
-    simple_network_args(parser, 4001)
+    sca.simple_network_args(parser, 4001)
     parser.add_argument("-d",
                         "--device",
                         default=None,
@@ -23,17 +21,17 @@ def get_argparser():
                         help="Do not home (reset to mechanical zero) on \
                         start (this needs to be done each time the hardware \
                         is power cycled")
-    add_common_args(parser)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = DDR05(args.device, auto_home=not args.no_auto_home)
 
-    simple_server_loop({"ddr05": dev}, bind_address_from_args(args), args.port)
+    simple_server_loop({"ddr05": dev}, sca.bind_address_from_args(args), args.port)
 
 
 if __name__ == "__main__":

--- a/oxart/frontend/thorlabs_ddr25_controller.py
+++ b/oxart/frontend/thorlabs_ddr25_controller.py
@@ -4,15 +4,13 @@ import argparse
 
 from oxart.devices.thorlabs_apt.driver import DDR25
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import (simple_network_args, init_logger_from_args,
-                                bind_address_from_args)
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
     parser = argparse.ArgumentParser(description="ARTIQ controller for the "
                                      "Thorlabs DDR25 motorised rotation mount")
-    simple_network_args(parser, 4000)
+    sca.simple_network_args(parser, 4000)
     parser.add_argument("-d",
                         "--device",
                         default=None,
@@ -23,17 +21,17 @@ def get_argparser():
                         help="Do not home (reset to mechanical zero) on \
                         start (this needs to be done each time the hardware \
                         is power cycled")
-    add_common_args(parser)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = DDR25(args.device, auto_home=not args.no_auto_home)
 
-    simple_server_loop({"ddr25": dev}, bind_address_from_args(args), args.port)
+    simple_server_loop({"ddr25": dev}, sca.bind_address_from_args(args), args.port)
 
 
 if __name__ == "__main__":

--- a/oxart/frontend/thorlabs_k10cr1_controller.py
+++ b/oxart/frontend/thorlabs_k10cr1_controller.py
@@ -4,15 +4,13 @@ import argparse
 
 from oxart.devices.thorlabs_apt.driver import K10CR1
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import (simple_network_args, init_logger_from_args,
-                                bind_address_from_args)
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
     parser = argparse.ArgumentParser(description="ARTIQ controller for the "
                                      "Thorlabs K10CR1 motorised rotation mount")
-    simple_network_args(parser, 4000)
+    sca.simple_network_args(parser, 4000)
     parser.add_argument("-d",
                         "--device",
                         default=None,
@@ -23,17 +21,17 @@ def get_argparser():
                         help="Do not home (reset to mechanical zero) on \
                         start (this needs to be done each time the hardware is \
                         power cycled")
-    add_common_args(parser)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = K10CR1(args.device, auto_home=not args.no_auto_home)
 
-    simple_server_loop({"k10cr1": dev}, bind_address_from_args(args), args.port)
+    simple_server_loop({"k10cr1": dev}, sca.bind_address_from_args(args), args.port)
 
 
 if __name__ == "__main__":

--- a/oxart/frontend/thorlabs_mdt693a_controller.py
+++ b/oxart/frontend/thorlabs_mdt693a_controller.py
@@ -4,27 +4,26 @@ import argparse
 
 from oxart.devices.thorlabs_mdt693a.driver import PiezoController
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
     parser = argparse.ArgumentParser(
         description="ARTIQ controller for the "
         "Thorlabs MDT693A 3-channel open-loop piezo controller")
-    simple_network_args(parser, 9001)
+    sca.simple_network_args(parser, 9001)
     parser.add_argument("-d",
                         "--device",
                         default=None,
                         required=True,
                         help="Device ip address")
-    add_common_args(parser)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = PiezoController(args.device)
 

--- a/oxart/frontend/thorlabs_mdt69xb_controller.py
+++ b/oxart/frontend/thorlabs_mdt69xb_controller.py
@@ -4,28 +4,27 @@ import argparse
 
 from oxart.devices.thorlabs_mdt69xb.driver import PiezoController
 from sipyco.pc_rpc import simple_server_loop
-from sipyco.common_args import simple_network_args, init_logger_from_args
-from oxart.tools import add_common_args
+import sipyco.common_args as sca
 
 
 def get_argparser():
     parser = argparse.ArgumentParser(
         description="ARTIQ controller for the "
         "Thorlabs MDT693B or MDT694B 3 (1) channel open-loop piezo controller")
-    simple_network_args(parser, 4002)
+    sca.simple_network_args(parser, 4002)
     parser.add_argument("-d",
                         "--device",
                         default=None,
                         required=True,
                         help="serial device. See documentation for how to "
                         "specify a USB Serial Number.")
-    add_common_args(parser)
+    sca.verbosity_args(parser)
     return parser
 
 
 def main():
     args = get_argparser().parse_args()
-    init_logger_from_args(args)
+    sca.init_logger_from_args(args)
 
     dev = PiezoController(args.device)
 


### PR DESCRIPTION
This function was only ever a wrapper for the varying names of
sipyco.common_args.verbosity_args during the transition to sipyco,
but prevented public use of the frontend scripts. Just use the
sipyco function now.

Fixes OxfordIonTrapGroup/oxart-devices#3

Passes flake8, yapf adds no changes to files in question.