### PR TITLE
(BREAKING) thorlabs_mdt39xb: save setpoint file in consistent location

### DIFF
--- a/conda/oxart-devices/meta.yaml
+++ b/conda/oxart-devices/meta.yaml
@@ -26,8 +26,10 @@ requirements:
     - python >=3.8
     - numpy
     - sipyco
+    - appdirs
   run:
     - python >=3.8
     - numpy
     - sipyco
+    - appdirs
     - pyzmq

--- a/oxart/devices/thorlabs_mdt69xb/driver.py
+++ b/oxart/devices/thorlabs_mdt69xb/driver.py
@@ -1,12 +1,21 @@
 import logging
 import serial
+import os
 import re
 import sys
 import asyncio
+import appdirs
 
 import sipyco.pyon as pyon
 
 logger = logging.getLogger(__name__)
+
+
+def _get_data_dir():
+    """Get the name of the data directory and create it if necessary"""
+    dir_ = appdirs.user_data_dir("oxart-devices", "oitg")
+    os.makedirs(dir_, exist_ok=True)
+    return dir_
 
 
 class PiezoController:
@@ -39,7 +48,9 @@ class PiezoController:
         self.v_limit = self.get_voltage_limit()
         logger.info("Device vlimit is {}".format(self.v_limit))
 
-        self.fname = "piezo_{}.pyon".format(self.get_serial())
+        self.data_dir = _get_data_dir()
+        self.filename = "piezo_{}.pyon".format(self.get_serial())
+        self.abs_filename = os.path.join(self.data_dir, self.filename)
         self.channels = {'x': -1, 'y': -1, 'z': -1}
         self._load_setpoints()
 
@@ -318,15 +329,17 @@ class PiezoController:
     def _load_setpoints(self):
         """Load setpoints from a file"""
         try:
-            self.channels = pyon.load_file(self.fname)
-            logger.info("Loaded '{}', channels: {}".format(self.fname, self.channels))
+            self.channels = pyon.load_file(self.abs_filename)
+            logger.info("Loaded '{}', channels: {}".format(self.filename,
+                                                           self.channels))
         except FileNotFoundError:
-            logger.warning("Couldn't find '{}', no setpoints loaded".format(self.fname))
+            logger.warning("Couldn't find '{}' in '{}', no setpoints loaded".format(
+                self.filename, self.data_dir))
 
     def _save_setpoints(self):
         """Write the setpoints out to file"""
-        pyon.store_file(self.fname, self.channels)
-        logger.debug("Saved '{}', channels: {}".format(self.fname, self.channels))
+        pyon.store_file(self.abs_filename, self.channels)
+        logger.debug("Saved '{}', channels: {}".format(self.filename, self.channels))
 
     def save_setpoints(self):
         """Deprecated: setpoints are saved internally on every set command"""

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     author="Oxford Ion Trap Quantum Computing Group",
     packages=find_packages(),
     entry_points={"console_scripts": scripts},
-    install_requires=["sipyco"],
+    install_requires=["sipyco", "appdirs"],
     # zip_safe=False apparently improves compatibility for namespace packages:
     # https://github.com/pypa/sample-namespace-packages/issues/6
     zip_safe=False,


### PR DESCRIPTION
I don't love this solution; I think it's a little messy that the driver specifies its
own directory rather than it being handled at the package level. However,
this does work (tested on Windows). Also happy to change the directory
location if there are strong opinions, currently on  Windows it resolves as

`C:\Users\<user>\AppData\Local\oitg\oxart-devices`

I called this a breaking change, although it depends on your definition of
breaking. Things are definitely funky if you don't copy the file, or set the
voltages directly rather than via the mediator.

------------------------------------
Solves OxfordIonTrapGroup/oxart-devices#4 by saving the file in a
consistent location.

To adapt to this change, users will need to copy the old setpoint
file to the new location. Running

`python -c "import oxart.devices.thorlabs_mdt69xb.driver as driver; print(driver._get_data_dir())"`

will both create the directory and print out its location.