### PR TITLE
aqctl_current_stabilizer: run server and connections in same loop

### DIFF
--- a/oxart/frontend/aqctl_current_stabilizer.py
+++ b/oxart/frontend/aqctl_current_stabilizer.py
@@ -35,7 +35,10 @@ def main():
     fb, ff = loop.run_until_complete(open_connections(args.device))
     dev = Stabilizer(fb, ff)
 
-    simple_server_loop({"stabilizer_current_sense": dev}, args.bind, args.port)
+    simple_server_loop({"stabilizer_current_sense": dev},
+                       args.bind,
+                       args.port,
+                       loop=loop)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the following error when run as a controller in ARTIQ:
```
RuntimeError: Task <Task pending name='Task-27' coro=<StreamReader.readline() 
running at [...]/asyncio/streams.py:540> cb=[_release_waiter(<Future pendi...5206210a0>()]>)() 
at [...]/asyncio/tasks.py:416]> got Future <Future pending> attached to a different loop
```