### PR TITLE
thorlabs mdt69xb: use serial_for_url instead of Serial

### DIFF
--- a/oxart/devices/thorlabs_mdt69xb/driver.py
+++ b/oxart/devices/thorlabs_mdt69xb/driver.py
@@ -24,10 +24,10 @@ class PiezoController:
     Tested with firmware versions 1.06 and 1.09.
     """
     def __init__(self, serial_addr):
-        self.port = serial.Serial(serial_addr,
-                                  baudrate=115200,
-                                  timeout=0.1,
-                                  write_timeout=0.1)
+        self.port = serial.serial_for_url(serial_addr,
+                                          baudrate=115200,
+                                          timeout=0.1,
+                                          write_timeout=0.1)
 
         self.echo = None
         self._purge()


### PR DESCRIPTION
Bring in line with other drivers to allow use of e.g. hwgrep when getting the device.