### PR TITLE
Add API for arbitrary commands

### DIFF
--- a/oxart/devices/scpi_synth/driver.py
+++ b/oxart/devices/scpi_synth/driver.py
@@ -8,6 +8,14 @@ class Synth:
         self.stream = get_stream(device)
         assert self.ping()
 
+    def write(self, cmd):
+        """ Write a string command. """
+        self.stream.write(cmd.encode())
+
+    def readline(self):
+        """ Read a line from the device. """
+        return self.stream.readline().decode()
+
     def identify(self):
         """ Return a device ID string. """
         self.stream.write("*IDN?\n".encode())


### PR DESCRIPTION
In some applications, it's easier just to write the string commands directly rather than transcribing the entire user manual. The SCPI syntax is usually pretty self explanatory.